### PR TITLE
Matthewa

### DIFF
--- a/idlak-data/en/nrules-default.xml
+++ b/idlak-data/en/nrules-default.xml
@@ -4,8 +4,8 @@
 
 <regex name="whitespace">
   <comment>
-    Overide default to regard hypens as wspace until norm rules added
-    to deal with hypenation.
+    Used by the tokeniser.
+    Whitespace characters.
   </comment>
   <exp>
     <![CDATA[^([ \n\t\r]+)]]>
@@ -14,7 +14,6 @@
 
   <regex name="separators">
     <comment>
-      Important: DO NOT REMOVE
       It is used by the tokeniser to tokenise these characters separately
     </comment>
     <exp>
@@ -24,14 +23,35 @@
 
   <regex name="alpha">
     <comment>
-      Important: Do not delete this regex, as it is used by the normaliser
-      internally.
-      Also, extend it with the language-specific letters.
+      Used by the tokeniser.
+      Also, extend it with the language-specific letters as required.
     </comment>
     <exp>
       <![CDATA[^[a-zA-Z_']+$]]>
     </exp>
   </regex>
+
+  <regex name="punc_strip">
+    <comment>
+      Used by the tokeniser.
+      Strip punctuation of the front and back and leave the rest as a token.
+    </comment>
+    <exp>
+      <![CDATA[^([()\[\]{}"'!?.,;:|]*)(.*?)([()\[\]{}"'!?.,;:|]*$)]]>
+    </exp>
+  </regex>
+
+  <!-- <regex name="punc_strip">
+    <comment>
+      Used by the tokeniser.      
+      Decompose tokens into separate tokens seprated by punctuation
+      Currently this will break number normalisation. e.g. 12,345 -> '12' ',' '345'
+    </comment>
+    <exp>
+      <![CDATA[^([()\[\]{}"'!?.,;:|]*)([^()\[\]{}"'!?.,;:|]*)([()\[\]{}"'!?.,;:|]*)]]>
+    </exp>
+  </regex> -->
+
 
   <lookup name="downcase">
     <comment>

--- a/src/idlaktxp/mod-tokenise.cc
+++ b/src/idlaktxp/mod-tokenise.cc
@@ -95,7 +95,7 @@ bool TxpTokenise::Process(pugi::xml_document* input) {
       }
       if (wspace.length()) {
         if (token.length())
-          ws = tkroot.append_child("ws");
+          ws = tk.parent().insert_child_after("ws", tk);
         else
           ws = node.parent().insert_child_before("ws", node);
         ntxt = ws.append_child(pugi::node_pcdata);

--- a/src/idlaktxp/txpnrules.cc
+++ b/src/idlaktxp/txpnrules.cc
@@ -57,7 +57,8 @@ void TxpNRules::Init(const TxpParseOptions &opts, const std::string &name) {
 
   rgxwspace_ = rgxwspace_default_ = pcre.Compile("^([ \n\t\r]+)");
   rgxsep_ = rgxsep_default_ = pcre.Compile("^([\\-\\+\\=\\/@]$)");
-  rgxpunc_ = rgxpunc_default_ = pcre.Compile("^([\\(\\)\\[\\]\\{\\}\\\"'!\\?\\.,;:\\|]*)([^\\(\\)\\[\\]\\{\\}\\\"!\\?\\.,;:\\|]*)([\\(\\)\\[\\]\\{\\}\\\"'!\\?\\.,;:\\|]*)");// NOLINT
+  // rgxpunc_ = rgxpunc_default_ = pcre.Compile("^([\\(\\)\\[\\]\\{\\}\\\"'!\\?\\.,;:\\|]*)([^\\(\\)\\[\\]\\{\\}\\\"!\\?;:\\|]*?)([\\(\\)\\[\\]\\{\\}\\\"'!\\?\\.,;:\\|]*)");// NOLINT
+  rgxpunc_ = rgxpunc_default_ = pcre.Compile("^([\\(\\)\\[\\]\\{\\}\\\"'!\\?\\.,;:\\|]*)(.*?)([\\(\\)\\[\\]\\{\\}\\\"'!\\?\\.,;:\\|]*)$");
   rgxalpha_ = rgxalpha_default_ = pcre.Compile("^[a-zA-Z_']+$");
   MakeLkp(&locallkps_, "downcase", "{\"A\":\"a\", \"B\":\"b\", \"C\":\"c\", \"D\":\"d\", \"E\":\"e\", \"F\":\"f\", \"G\":\"g\", \"H\":\"h\", \"I\":\"i\", \"J\":\"j\", \"K\":\"k\", \"L\":\"l\", \"M\":\"m\", \"N\":\"n\", \"O\":\"o\", \"P\":\"p\", \"Q\":\"q\", \"R\":\"r\", \"S\":\"s\", \"T\":\"t\", \"U\":\"u\", \"V\":\"v\", \"W\":\"w\", \"X\":\"x\", \"Y\":\"y\", \"Z\":\"z\"}");// NOLINT
   MakeLkp(&locallkps_, "convertillegal", "{\"À\":\"A\", \"Á\":\"A\", \"Â\":\"A\", \"Ã\":\"A\", \"Å\":\"A\", \"Æ\":\"AE\", \"à\":\"a\", \"á\":\"a\", \"â\":\"a\", \"ã\":\"a\", \"å\":\"a\", \"æ\":\"ae\", \"Ç\":\"C\", \"ç\":\"c\", \"È\":\"E\", \"É\":\"E\", \"Ê\":\"E\", \"Ë\":\"E\", \"è\":\"e\", \"é\":\"e\", \"ê\":\"e\", \"ë\":\"e\", \"Ì\":\"I\", \"Í\":\"I\", \"Î\":\"I\", \"Ï\":\"I\", \"ì\":\"i\", \"í\":\"i\", \"î\":\"i\", \"ï\":\"i\", \"Ñ\":\"N\", \"ñ\":\"n\", \"Ò\":\"O\", \"Ó\":\"O\", \"Ô\":\"O\", \"Õ\":\"O\", \"Ø\":\"O\", \"ò\":\"o\", \"ó\":\"o\", \"ô\":\"o\", \"õ\":\"o\", \"ø\":\"o\", \"Ù\":\"U\", \"Ú\":\"U\", \"Û\":\"U\", \"Ű\":u\"Ü\", \"ù\":\"u\", \"ú\":\"u\", \"û\":\"u\", \"ű\":u\"ü\", \"Ý\":\"Y\", \"ý\":\"y\"}");// NOLINT
@@ -76,9 +77,8 @@ bool TxpNRules::Parse(const std::string &tpdb) {
     if (rgx) rgxwspace_ = rgx;
     rgx = GetRgx("separators");
     if (rgx) rgxsep_ = rgx;
-    // Current punc_strip_full in tpdb not appropriate use hard coded version
-    // rgx = GetRgx("punc_strip_full");
-    // if (rgx) rgxpunc_ = rgx;
+    rgx = GetRgx("punc_strip");
+    if (rgx) rgxpunc_ = rgx;
     rgx = GetRgx("alpha");
     if (rgx) rgxalpha_ = rgx;
   } else {


### PR DESCRIPTION
Temporarily put tokenination back to whitespace delimited tokens rhather than addition punctuation internal tokenisation.