### PR TITLE
Fixed error on default lookups replacing lookup items rather than tab…

### DIFF
--- a/src/idlaktxp/idlak-common.h
+++ b/src/idlaktxp/idlak-common.h
@@ -37,10 +37,6 @@ namespace kaldi {
 typedef std::map<std::string, std::string> LookupMap;
 /// Generic string/string pair
 typedef std::pair<std::string, std::string> LookupItem;
-/// Generic string to string map lookup
-typedef std::map<std::string, LookupMap> LookupMapMap;
-/// Generic string/lookupmap pair
-typedef std::pair<std::string, LookupMap> LookupMapItem;
 /// Generic string to vector index
 typedef std::map<std::string, int32> LookupInt;
 /// Generic string/vector index pair

--- a/src/idlaktxp/txpnrules.h
+++ b/src/idlaktxp/txpnrules.h
@@ -37,6 +37,11 @@ namespace kaldi {
 typedef std::map<std::string, pcre*> RgxMap;
 /// Regular expression name/ pcre regular expression pair
 typedef std::pair<std::string, pcre*> RgxItem;
+/// Lookup map of lookup maps
+typedef std::map<std::string, LookupMap * > LookupMapMap;
+/// string/LookupMap pair
+typedef std::pair<std::string, LookupMap * > LookupMapItem;
+
 
 struct TxpCaseInfo;
 
@@ -109,7 +114,7 @@ class TxpNRules: public TxpXmlData {
   void EndCData();
   void CharHandler(const char* data, int32 len);
   /// Parses the lookup format in the cdata into a map and adds it to lkps
-  int32 MakeLkp(LookupMap *lkps,
+  int32 MakeLkp(LookupMapMap *lkps,
                 const std::string &name,
                 const std::string &cdata);
   /// Parser status currently in cdata element
@@ -140,9 +145,9 @@ class TxpNRules: public TxpXmlData {
   /// Regex for finding lexicon valid character (e.g. English a-z)
   const pcre* rgxalpha_default_;
   /// Map of hard coded lookup tables
-  LookupMap locallkps_;
+  LookupMapMap locallkps_;
   /// Map of lookup tables in tpdb file
-  LookupMap lkps_;
+  LookupMapMap lkps_;
   /// Map of Regexes in tpdb file
   RgxMap rgxs_;
   /// Records type of ellement during expat parse

--- a/src/idlaktxp/txpparse-options.cc
+++ b/src/idlaktxp/txpparse-options.cc
@@ -54,7 +54,6 @@ TxpParseOptions::TxpParseOptions(const char *usage)
     : ParseOptions(usage) {
   std::istringstream is(txpconfigdefault);
   std::string line, key, value, *stringptr;
-  LookupMapItem item;
   RegisterStandard("tpdb", &tpdb_,
                    "Text processing database (directory XML language/speaker files)"); //NOLINT
   while (std::getline(is, line)) {


### PR DESCRIPTION
…les when not present by using a map of maps rather than a single map with a table name as a part of the key.

Tested with valgrind. Also checked make test produces same output. Tested by remove accented e from en nrules-default.xml and put cafe (with accent through the system). All seems good.
