### PR TITLE
improving tangle scripts to run on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Idlak is a project to build an end-to-end parametric TTS
 system within Kaldi, to be distributed with the same Apache 2 licence.
 It contains a robust front-end, voice building tools, speech analysis
 utilities, and DNN tools suitable for parametric synthesis. It also contains
-an example of using Idlak as an end-to-end TTS system, in egs/tts_dnn_arctic/s1
+an example of using Idlak as an end-to-end TTS system, in idlak-egs/tts_tangle_arctic/s2
 
 Note that the kaldi structure has been maintained and the tool building
 procedure is identical.
@@ -31,7 +31,7 @@ and appears in src/html/
 To run the example system builds, see `egs/README.txt`.
 
 If you are reading this, you probably want to build the "Tangle" demo, which
-is located egs/tts_dnn_arctic/s1.
+is located idlak-egs/tts_tangle_arctic/s2.
 
 If you encounter problems (and you probably will), please do not hesitate to
 contact the developers (see below). In addition to specific questions, please

--- a/idlak-egs/tts_tangle_arctic/s2/local/synthesis_voice_pitch.sh
+++ b/idlak-egs/tts_tangle_arctic/s2/local/synthesis_voice_pitch.sh
@@ -40,7 +40,7 @@ dnndir=$voice_dir/acoustic
 cleanup=1
 datadir=`mktemp -d`
 mkdir -p $datadir
-tpdb=`readlink -f $voice_dir/lang/`
+tpdb=`realpath $voice_dir/lang/`
 
 [ -f path.sh ] && . ./path.sh;
 

--- a/idlak-egs/tts_tangle_arctic/s2/local/tangle_train.sh
+++ b/idlak-egs/tts_tangle_arctic/s2/local/tangle_train.sh
@@ -145,12 +145,18 @@ if [ $stage -le 0 ]; then
 
         # Split train, dev sets
         # linux and mac have to do this in different ways
-        head -n-$nodev $flist > /dev/null 2>&1
-        if [ $? -eq 0 ]; then
-            head -n-$nodev $flist | sed s'|^\(.*\)|\1 '$audio_dir/'\1.wav|' | sort -u > $datadir/train/$spk/wav.scp
-        else
-            tail -r $flist | tail -n +$nodev | tail -r | sed s'|^\(.*\)|\1 '$audio_dir/'\1.wav|' | sort -u  > $datadir/train/$spk/wav.scp
-        fi
+        case $(uname | tr '[:upper:]' '[:lower:]') in
+            linux*) 
+                head -n-$nodev $flist 
+                ;;
+            darwin*) 
+                tail -r $flist | tail -n +$nodev | tail -r 
+                ;;
+            *) 
+                echo "ERROR : unknown system $(uname | tr '[:upper:]' '[:lower:]') " 
+                ;;
+        esac | sed s'|^\(.*\)|\1 '$audio_dir/'\1.wav|' | sort -u > $datadir/train/$spk/wav.scp
+
         cat $datadir/train/$spk/wav.scp >> $datadir/train/wav.scp
 
         tail -n$nodev $flist | sed s'|^\(.*\)|\1 '$audio_dir/'\1.wav|' | sort -u  > $datadir/dev/$spk/wav.scp


### PR DESCRIPTION
The scripts `synthesis_voice_pitch.sh` and `tangle_train.sh` in   `idlak-egs/tts_tangle_arctic/s2/local` were not working on MacOS because a different  usage  on MacOS for the commands `head` and `readlink`. The bad command `readlink -f` was replaced by its equivalent `realpath`  and  where it was necessary `OS type` was checked by `uname`.

The documentation `README.md` has been updated with the correct path for the `Tangle` examples.

